### PR TITLE
Fix variable name typo

### DIFF
--- a/lehigh-inventory/SheetAddon/code.gs
+++ b/lehigh-inventory/SheetAddon/code.gs
@@ -71,7 +71,7 @@ function checkStatus(itemBarcode,scannedIndicator) {
 
   var itemPutResponse = UrlFetchApp.fetch(baseOkapi + "/item-storage/items/" + itemId,putOptions);
   for(i in itemPutResponse) {
-     Logger.log(i + ": " + response[i]);
+     Logger.log(i + ": " + itemPutResponse[i]);
   }
   if (itemPutResponse.getResponseCode() != 204) {
       var ui = SpreadsheetApp.getUi();


### PR DESCRIPTION
Execution was failing on this line.  Fixed in the published add-on, mirroring the fix here.